### PR TITLE
Use option to remove migrations on uninstall

### DIFF
--- a/uninstall.rb
+++ b/uninstall.rb
@@ -10,21 +10,23 @@ def column_exists?(table, column)
   end
 end
 
-# Remove the identity_card_number field to the User model
-if column_exists?(:users, :identity_card_number)
-  migration_file_path = '../db/migrate/derechoapreguntar_theme_add_identity_card_number_to_user'
-  require File.expand_path migration_file_path, __FILE__
-  DerechoaPreguntarThemeAddIdentityCardNumberToUser.down
-end
+if ENV['REMOVE_MIGRATIONS']
+  # Remove the identity_card_number field to the User model
+  if column_exists?(:users, :identity_card_number)
+    migration_file_path = '../db/migrate/derechoapreguntar_theme_add_identity_card_number_to_user'
+    require File.expand_path migration_file_path, __FILE__
+    DerechoaPreguntarThemeAddIdentityCardNumberToUser.down
+  end
 
-if table_exists?(:general_laws)
-  migration_file_path = '../db/migrate/derechoapreguntar_theme_create_general_laws'
-  require File.expand_path migration_file_path, __FILE__
-  DerechoaPreguntarThemeCreateGeneralLaws.down
-end
+  if table_exists?(:general_laws)
+    migration_file_path = '../db/migrate/derechoapreguntar_theme_create_general_laws'
+    require File.expand_path migration_file_path, __FILE__
+    DerechoaPreguntarThemeCreateGeneralLaws.down
+  end
 
-if column_exists?(:general_laws, :user_id)
-  migration_file_path = '../db/migrate/derechoapreguntar_theme_add_user_id_to_general_laws'
-  require File.expand_path migration_file_path, __FILE__
-  DerechoaPreguntarThemeAddUserIdToGeneralLaws.down
+  if column_exists?(:general_laws, :user_id)
+    migration_file_path = '../db/migrate/derechoapreguntar_theme_add_user_id_to_general_laws'
+    require File.expand_path migration_file_path, __FILE__
+    DerechoaPreguntarThemeAddUserIdToGeneralLaws.down
+  end
 end


### PR DESCRIPTION
Running the migrations trashes any data in the new columns and tables,
so if you're only upgrading the theme you don't want this to happen. Run
the migrations by setting the 'REMOVE_MIGRATIONS' env var.
