### PR TITLE
Move privacy policy link to registration

### DIFF
--- a/lib/views/help/_sidebar.es.html.erb
+++ b/lib/views/help/_sidebar.es.html.erb
@@ -4,10 +4,8 @@
         <li><%= link_to_unless_current "Quienes somos", help_about_path %></li>
         <li><%= link_to_unless_current "Guía para solicitantes", help_requesting_path %></li>
         <li><%= link_to_unless_current "Tu Privacidad", help_privacy_path %></li>
-        <li><%= link_to_unless_current "Política de privacidad", help_general_path(:action => 'privacy_policy') %></li>
         <li><%= link_to_unless_current "Información para Instituciones", help_officers_path %></li>
         <li><%= link_to_unless_current "Búsqueda avanzada", advanced_search_path %></li>
-        <li><%= link_to_unless_current "Condiciones de Uso", help_general_path(:action => 'terms_of_use') %></li>
         <li><%= link_to_unless_current "Basado en Alaveteli", help_alaveteli_path %></li>
 
         <li><%= link_to_unless_current "API para programadores", help_api_path %>

--- a/lib/views/user/_signup.html.erb
+++ b/lib/views/user/_signup.html.erb
@@ -56,8 +56,10 @@
 
     <p class="form_checkbox">
         <%= f.check_box :terms, :tabindex => 110 %>
-        <%= f.label :terms, _('Please confirm that you have read the <a href="{{url}}">Terms of Use</a>',
-                      :url => help_general_path(:action => 'terms_of_use')) %>
+        <%= f.label :terms, _('Please confirm that you have read the <a href="{{terms_url}}">Terms of Use</a> and <a href="{{privacy_url}}">Privacy Policy</a>.',
+                  :terms_url => help_general_path(:action => 'terms_of_use'),
+                  :privacy_url => help_general_path(:action => 'privacy_policy')) %>
+
     </p>
 
     <% if @request_from_foreign_country %>


### PR DESCRIPTION
Remove privacy policy and terms links from help menu.
