### PR TITLE
Update api.es.html.erb

### DIFF
--- a/lib/views/help/api.es.html.erb
+++ b/lib/views/help/api.es.html.erb
@@ -44,7 +44,7 @@
 
       <p>Solicitudes, usuarios y autoridades, todos tienen una versión JSON con informaciones básicas sobre ellos. Cada formato Atom tiene un equivalente JSON con informaciones sobre los objetos incluidos en el feed.</p>
 
-    <h2>Información sobre todos los entidades públicas de Nicaragua</h2>
+    <h2>Información sobre todas las entidades públicas de Nicaragua</h2>
       <p>Un fichero CSV con información sobre todos las entidades públicas de Nicaragua está disponible en el sitio web de derechoapreguntar.org: <%= link_to "all-authorities.csv", all_public_bodies_csv_url() %>
       </p>
 


### PR DESCRIPTION
Se cambio: Información sobre todos los entidades públicas de Nicaragua por: Información sobre todas las entidades públicas de Nicaragua